### PR TITLE
Update SDK version to 52 and enable new architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,20 +16,23 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "newArchEnabled": true
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "newArchEnabled": true
     },
     "web": {
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
       "expo-router",
-      "expo-secure-store"
+      "expo-secure-store",
+      "expo-build-properties"
     ]
   }
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import { View, Button, Text, Image } from 'react-native';
-import { Audio } from 'expo-av';
+import { Video } from 'expo-video';
 import * as Speech from 'expo-speech';
 
 import { getConfig } from '../util/settings';
 import { oaTranscribeRecording } from '../util/openai';
 
 export default function Tab() {
-  const [recording, setRecording] = useState<Audio.Recording | undefined>();
-  const [permissionResponse, requestPermission] = Audio.usePermissions();
+  const [recording, setRecording] = useState<Video.Recording | undefined>();
+  const [permissionResponse, requestPermission] = Video.usePermissions();
   const [recordingUri, setRecordingUri] = useState<string | undefined>();
   const [transcription, setTranscription] = useState<string | undefined>();
   const [transcribing, setTranscribing] = useState<boolean>(false);
@@ -20,13 +20,13 @@ export default function Tab() {
         console.log('Requesting permission..');
         await requestPermission();
       }
-      await Audio.setAudioModeAsync({
+      await Video.setVideoModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,
       });
 
       console.log('Starting recording..');
-      const { recording } = await Audio.Recording.createAsync(Audio.RecordingOptionsPresets.HIGH_QUALITY
+      const { recording } = await Video.Recording.createAsync(Video.RecordingOptionsPresets.HIGH_QUALITY
       );
       setRecording(recording);
       console.log('Recording started');
@@ -39,7 +39,7 @@ export default function Tab() {
     console.log('Stopping recording..');
     setRecording(undefined);
     await recording.stopAndUnloadAsync();
-    await Audio.setAudioModeAsync(
+    await Video.setVideoModeAsync(
       {
         allowsRecordingIOS: false,
       }
@@ -50,7 +50,7 @@ export default function Tab() {
   }
 
   async function playRecoding() {
-    const { sound } = await Audio.Sound.createAsync({ uri: recordingUri, name: 'recording', type: 'audio/m4a' });
+    const { sound } = await Video.Sound.createAsync({ uri: recordingUri, name: 'recording', type: 'video/mp4' });
     await sound.playAsync();
   }
 
@@ -60,7 +60,7 @@ export default function Tab() {
       setTranscribing(true);
       const fileData = await fetch(recordingUri);
       const blob = await fileData.blob();
-      const file = new File([blob], 'recording', { type: 'audio/m4a', lastModified: Date.now() });
+      const file = new File([blob], 'recording', { type: 'video/mp4', lastModified: Date.now() });
 
       const response = oaTranscribeRecording(file);
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ["nativewind/babel"],
+    plugins: ["nativewind/babel", "expo-build-properties"],
   };
 };


### PR DESCRIPTION
Update SDK version to the new architecture as per Expo documentation.

* **app.json**
  - Enable `newArchEnabled` for both `ios` and `android` platforms.
  - Add `expo-build-properties` plugin to the `plugins` array.

* **babel.config.js**
  - Add `expo-build-properties` to the `plugins` array.

* **app/(tabs)/index.tsx**
  - Replace `expo-av` with `expo-video` for audio recording and playback.
  - Update import statements to use `expo-video`.
  - Update state and function calls to use `Video` instead of `Audio`.
